### PR TITLE
feat: 프로젝트 structure 세팅

### DIFF
--- a/src/main/java/com/double_o/dambap/common/dto/FieldInvalidResponse.java
+++ b/src/main/java/com/double_o/dambap/common/dto/FieldInvalidResponse.java
@@ -1,0 +1,12 @@
+package com.double_o.dambap.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FieldInvalidResponse {
+
+    private String errorCode;
+    private String errorMessage;
+}

--- a/src/main/java/com/double_o/dambap/common/dto/SuccessResponse.java
+++ b/src/main/java/com/double_o/dambap/common/dto/SuccessResponse.java
@@ -1,0 +1,11 @@
+package com.double_o.dambap.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SuccessResponse {
+
+    private String message;
+}

--- a/src/main/java/com/double_o/dambap/common/entity/BaseEntity.java
+++ b/src/main/java/com/double_o/dambap/common/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.double_o.dambap.common.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Column(name = "created_at")
+    @CreatedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at")
+    @LastModifiedDate
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/double_o/dambap/common/model/ResponseDto.java
+++ b/src/main/java/com/double_o/dambap/common/model/ResponseDto.java
@@ -1,0 +1,41 @@
+package com.double_o.dambap.common.model;
+
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseDto<T> implements Serializable {
+
+    private T data;
+    private String errorMessage;
+
+    public ResponseDto(T data) {
+        this.data = data;
+    }
+
+    public static <T> ResponseEntity<ResponseDto<T>> ok(T data) {
+        return ResponseEntity.ok(new ResponseDto<T>(data));
+    }
+
+    public static <T> ResponseEntity<ResponseDto<T>> created(T data) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseDto<T>(data));
+    }
+
+    public static <T> ResponseEntity<ResponseDto<T>> notFound() {
+        ResponseDto<T> responseDto = new ResponseDto<>();
+        responseDto.setErrorMessage("The requested resource does not exist.");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseDto);
+    }
+
+    public static ResponseEntity<Void> noContent() {
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+}

--- a/src/main/java/com/double_o/dambap/config/jpa/JpaConfig.java
+++ b/src/main/java/com/double_o/dambap/config/jpa/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.double_o.dambap.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/double_o/dambap/exception/BusinessException.java
+++ b/src/main/java/com/double_o/dambap/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.double_o.dambap.exception;
+
+import com.double_o.dambap.exception.dto.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private ErrorType errorType;
+    private String customMessage;
+
+    public BusinessException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+    }
+
+    public BusinessException(ErrorType errorType, String customMessage) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.customMessage = customMessage;
+    }
+}

--- a/src/main/java/com/double_o/dambap/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/double_o/dambap/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.double_o.dambap.exception;
+
+import com.double_o.dambap.common.dto.FieldInvalidResponse;
+import com.double_o.dambap.exception.dto.ErrorDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 사용자 정의 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorDto> handleBusinessException(final BusinessException e) {
+        log.error("[Error] BusinessException -> {}", e.getMessage());
+        return ResponseEntity.status(e.getErrorType().getStatus())
+                .body(new ErrorDto(e.getErrorType()));
+    }
+
+    // 메소드 파라미터의 not valid 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<FieldInvalidResponse> handleFieldException(
+            final MethodArgumentNotValidException e
+    ) {
+        BindingResult bindingResult = e.getBindingResult();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(FieldInvalidResponse.builder()
+                        .errorCode(bindingResult.getFieldError().getCode())
+                        .errorMessage(bindingResult.getFieldError().getDefaultMessage())
+                        .build());
+    }
+}

--- a/src/main/java/com/double_o/dambap/exception/dto/ErrorDto.java
+++ b/src/main/java/com/double_o/dambap/exception/dto/ErrorDto.java
@@ -1,0 +1,17 @@
+package com.double_o.dambap.exception.dto;
+
+import java.io.Serializable;
+import lombok.Getter;
+
+@Getter
+public class ErrorDto implements Serializable {
+
+    private final String message;
+    private final String reason;
+
+    public ErrorDto(ErrorType message) {
+        this.message = message.name();
+        this.reason = message.getMessage();
+    }
+
+}

--- a/src/main/java/com/double_o/dambap/exception/dto/ErrorType.java
+++ b/src/main/java/com/double_o/dambap/exception/dto/ErrorType.java
@@ -1,0 +1,14 @@
+package com.double_o.dambap.exception.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorType {
+    CONFLICT_ERROR(HttpStatus.BAD_REQUEST, "예기치 못한 에러가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
## 🚀 연관된 이슈

- resolve: #24 

## ✨ 작업 내용

- BaseEntity 를 상속 받아 생성 및 수정 시간과 같은 공통 필드의 중복을 없앴습니다.
- Jpa Auditing 기능을 통해 @CreatedDate, @LastModifiedDate 같은 필드 자동 설정 기능을 활성화하였습니다.
- `GlobalExceptionHandler` 작성을 통해 컨트롤러에서 발생한 1) 전역 예외 및 커스텀 예외인 `BusinessException`을 처리하고, 2) 메소드 파라미터의 not valid인 `MethodArgumentNotValidException`을 잡아 처리합니다.