### PR TITLE
feat: 미디어 업로드를 위한 컨트롤러 개발 및 s3 저장소 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -103,7 +103,7 @@ jobs:
             fi
 
             # 새 컨테이너 실행
-            sudo docker run -d -p 8081:8080 --name ${{ env.SERVICE_NAME }}-${{ env.IMAGE_TAG }} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
+            sudo docker run -d -p 8080:8080 --name ${{ env.SERVICE_NAME }}-${{ env.IMAGE_TAG }} ${{ secrets.DOCKER_USERNAME }}/${{ env.SERVICE_NAME }}:${{env.IMAGE_TAG}}
 
             # 이미지 정리
             sudo docker image prune -f

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,6 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-
 name: Dambap CI/CD
 
 on:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
+
 name: Dambap CI/CD
 
 on:

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.7.7'
 
+	// s3
+	implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
+
 	// database
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/double_o/dambap/exception/dto/ErrorType.java
+++ b/src/main/java/com/double_o/dambap/exception/dto/ErrorType.java
@@ -9,6 +9,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     CONFLICT_ERROR(HttpStatus.BAD_REQUEST, "예기치 못한 에러가 발생했습니다."),
 
+    // S3 예외
+    EMPTY_IMAGE_ERROR(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
+    IMAGE_UPLOAD_FAILED_ERROR(HttpStatus.BAD_REQUEST, "이미지 업로드에 실패하였습니다."),
+    MEDIA_MAX_SIZE_3_ERROR(HttpStatus.BAD_REQUEST, "미디어는 최대 3개까지 등록 가능합니다."),
+
     // register 예외
     EMAIL_DUPLICATE_ERROR(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
     CONFIRM_PASSWORD_NOT_MATCH_ERROR(HttpStatus.BAD_REQUEST, "패스워드가 확인 패스워드랑 일치하지 않습니다."),
@@ -19,7 +24,6 @@ public enum ErrorType {
 
     //auth 예외
     NON_IDENTICAL_USER_ERROR(HttpStatus.FORBIDDEN, "작성자와 접근자가 일치하지 않습니다."),
-    WRITER_CANNOT_RECOMMEND_ERROR(HttpStatus.FORBIDDEN, "자신의 게시물은 추천할 수 없습니다."),
     USED_ACCESS_TOKEN_ERROR(HttpStatus.FORBIDDEN, "이미 사용된 엑세스 토큰입니다"),
     USED_REFRESH_TOKEN_ERROR(HttpStatus.FORBIDDEN, "이미 사용된 리프레시 토큰입니다"),
     REFRESH_TOKEN_MISMATCH_ERROR(HttpStatus.FORBIDDEN, "엑세스 토큰이 일치하지 않습니다"),

--- a/src/main/java/com/double_o/dambap/exception/s3/S3InvalidException.java
+++ b/src/main/java/com/double_o/dambap/exception/s3/S3InvalidException.java
@@ -1,0 +1,11 @@
+package com.double_o.dambap.exception.s3;
+
+import com.double_o.dambap.exception.BusinessException;
+import com.double_o.dambap.exception.dto.ErrorType;
+
+public class S3InvalidException extends BusinessException {
+
+    public S3InvalidException(ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/com/double_o/dambap/post/utils/MediaConstants.java
+++ b/src/main/java/com/double_o/dambap/post/utils/MediaConstants.java
@@ -1,0 +1,6 @@
+package com.double_o.dambap.post.utils;
+
+public class MediaConstants {
+
+    public static final int MEDIA_MAX_SIZE = 3;
+}

--- a/src/main/java/com/double_o/dambap/s3/application/S3Uploader.java
+++ b/src/main/java/com/double_o/dambap/s3/application/S3Uploader.java
@@ -1,0 +1,60 @@
+package com.double_o.dambap.s3.application;
+
+import com.double_o.dambap.s3.utils.CommonUtils;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3Uploader {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {
+            log.warn("image is null");
+            return "";
+        }
+
+        try {
+            // UUID 와 파일 확장자를 결합하여 고유한 파일명 생성
+            String originalFilename = multipartFile.getOriginalFilename();
+            String fileName = CommonUtils.buildFileName(originalFilename);
+
+            // 파일 업로드를 위한 요청 생성
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(fileName)
+                    .contentType(multipartFile.getContentType())
+                    .contentLength(multipartFile.getSize())
+                    .acl("public-read") // 공개 읽기 권한 추가
+                    .build();
+
+            // 파일 업로드
+            RequestBody requestBody = RequestBody.fromBytes(multipartFile.getBytes());
+            s3Client.putObject(putObjectRequest, requestBody);
+
+            // URL 생성하여 반환
+            return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucketName,
+                    s3Client.serviceClientConfiguration().region().toString(),
+                    fileName);
+
+        } catch (IOException e) {
+            log.error("Failed to upload file to S3", e);
+            throw new RuntimeException("파일 업로드에 실패했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/double_o/dambap/s3/config/S3Config.java
+++ b/src/main/java/com/double_o/dambap/s3/config/S3Config.java
@@ -1,0 +1,45 @@
+package com.double_o.dambap.s3.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Slf4j
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(this::awsCredentials)
+                .region(Region.of(region))
+                .build();
+    }
+
+    private AwsCredentials awsCredentials() {
+        return new AwsCredentials() {
+            @Override
+            public String accessKeyId() {
+                return accessKey;
+            }
+
+            @Override
+            public String secretAccessKey() {
+                return secretKey;
+            }
+        };
+    }
+}

--- a/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
+++ b/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
@@ -1,0 +1,56 @@
+package com.double_o.dambap.s3.presentation;
+
+import static com.double_o.dambap.post.utils.MediaConstants.MEDIA_MAX_SIZE;
+
+import com.double_o.dambap.common.model.ResponseDto;
+import com.double_o.dambap.exception.dto.ErrorType;
+import com.double_o.dambap.exception.post.PostInvalidException;
+import com.double_o.dambap.exception.s3.S3InvalidException;
+import com.double_o.dambap.s3.application.S3Uploader;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping(path = "/api/images")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3Uploader s3Uploader;
+
+    @Operation(summary = "이미지 업로드", description = "S3를 이용한 이미지 업로드 전용 api")
+    @ApiResponse(responseCode = "200", description = "이미지 업로드 성공, 이미지 url 반환")
+    @PostMapping
+    public ResponseEntity<?> uploadImages(@RequestParam("images") List<MultipartFile> images) {
+        try {
+            List<String> mediaUrls = images.stream()
+                    .map(s3Uploader::uploadFile)
+                    .toList();
+
+            // 파일이 비었는지 검사
+            if (mediaUrls.isEmpty() || mediaUrls.stream().anyMatch(String::isEmpty)) {
+                throw new S3InvalidException(ErrorType.EMPTY_IMAGE_ERROR);
+            }
+
+            // 미디어 등록은 최대 3개로 제한
+            if (images.size() > MEDIA_MAX_SIZE) {
+                throw new PostInvalidException(ErrorType.MEDIA_MAX_SIZE_3_ERROR);
+            }
+
+            log.debug("Successfully uploaded image. URL: {}", mediaUrls.size());
+            return ResponseDto.ok(mediaUrls);
+        } catch (Exception e) {
+            log.error("Failed to upload images", e);
+            throw new S3InvalidException(ErrorType.IMAGE_UPLOAD_FAILED_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
+++ b/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
@@ -4,7 +4,6 @@ import static com.double_o.dambap.s3.utils.MediaConstants.MEDIA_MAX_SIZE;
 
 import com.double_o.dambap.common.model.ResponseDto;
 import com.double_o.dambap.exception.dto.ErrorType;
-import com.double_o.dambap.exception.post.PostInvalidException;
 import com.double_o.dambap.exception.s3.S3InvalidException;
 import com.double_o.dambap.s3.application.S3Uploader;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping(path = "/api/images")
+@RequestMapping(path = "/api/v1/images")
 @RequiredArgsConstructor
 public class S3Controller {
 
@@ -32,25 +31,36 @@ public class S3Controller {
     @PostMapping
     public ResponseEntity<?> uploadImages(@RequestParam("images") List<MultipartFile> images) {
         try {
+            validateEmptyFiles(images);
+            validateMediaMaxSize(images);
+
             List<String> mediaUrls = images.stream()
                     .map(s3Uploader::uploadFile)
                     .toList();
-
-            // 파일이 비었는지 검사
-            if (mediaUrls.isEmpty() || mediaUrls.stream().anyMatch(String::isEmpty)) {
-                throw new S3InvalidException(ErrorType.EMPTY_IMAGE_ERROR);
-            }
-
-            // 미디어 등록은 최대 3개로 제한
-            if (images.size() > MEDIA_MAX_SIZE) {
-                throw new PostInvalidException(ErrorType.MEDIA_MAX_SIZE_3_ERROR);
-            }
 
             log.debug("Successfully uploaded image. URL: {}", mediaUrls.size());
             return ResponseDto.ok(mediaUrls);
         } catch (Exception e) {
             log.error("Failed to upload images", e);
             throw new S3InvalidException(ErrorType.IMAGE_UPLOAD_FAILED_ERROR);
+        }
+    }
+
+
+    /** 파일이 비었는지 검사 */
+    private void validateEmptyFiles(List<MultipartFile> images) {
+        if (images == null || images.isEmpty()) {
+            throw new S3InvalidException(ErrorType.EMPTY_IMAGE_ERROR);
+        }
+        if (images.stream().anyMatch(img -> img.isEmpty() || img.getSize() == 0)) {
+            throw new S3InvalidException(ErrorType.EMPTY_IMAGE_ERROR);
+        }
+    }
+
+    /** 파일 개수 검사 (최대 MEDIA_MAX_SIZE) */
+    private void validateMediaMaxSize(List<MultipartFile> images) {
+        if (images.size() > MEDIA_MAX_SIZE) {
+            throw new S3InvalidException(ErrorType.MEDIA_MAX_SIZE_3_ERROR);
         }
     }
 }

--- a/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
+++ b/src/main/java/com/double_o/dambap/s3/presentation/S3Controller.java
@@ -1,6 +1,6 @@
 package com.double_o.dambap.s3.presentation;
 
-import static com.double_o.dambap.post.utils.MediaConstants.MEDIA_MAX_SIZE;
+import static com.double_o.dambap.s3.utils.MediaConstants.MEDIA_MAX_SIZE;
 
 import com.double_o.dambap.common.model.ResponseDto;
 import com.double_o.dambap.exception.dto.ErrorType;

--- a/src/main/java/com/double_o/dambap/s3/utils/CommonUtils.java
+++ b/src/main/java/com/double_o/dambap/s3/utils/CommonUtils.java
@@ -1,0 +1,17 @@
+package com.double_o.dambap.s3.utils;
+
+import java.util.UUID;
+
+public class CommonUtils {
+
+    public static final String FILE_EXTENSION_SEPARATOR = ".";
+
+    public static String buildFileName(String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR);
+        String fileExtension = originalFileName.substring(fileExtensionIndex)
+                .toLowerCase(); // 확장자 소문자로 변환
+        String uuid = UUID.randomUUID().toString();
+
+        return uuid + fileExtension;
+    }
+}

--- a/src/main/java/com/double_o/dambap/s3/utils/MediaConstants.java
+++ b/src/main/java/com/double_o/dambap/s3/utils/MediaConstants.java
@@ -1,4 +1,4 @@
-package com.double_o.dambap.post.utils;
+package com.double_o.dambap.s3.utils;
 
 public class MediaConstants {
 


### PR DESCRIPTION
<!--
제목은 다음과 같이 정합니다.
domain: 진행한 내용 요약
domain -> feat / error / ect
+ 필요 없는 내용은 지워주세요.
-->

## 🚀 연관된 이슈

- resolve: #32 

## ✨ 작업 내용

- 게시글 api 와 분리된 미디어 전용 api를 개발하였습니다.
- 미디어 업로드 요청 시 순서는 다음과 같습니다
  - (업로드할 이미지가 존재하는 경우에만)이미지를 s3에 저장하는 api 요청 후 url 반환받음
  - 해당 url을 request에 포함하여 게시글 등록 api 요청
- 업로드할 이미지가 없을 경우 s3 api 는 요청하지 않습니다.
- 클라이언트에서 이미지 등록 시 반드시 업로드 순서대로 배열 보내주세요! + 이미지 조회 시 반환되는 순서 그대로 지켜주세요!

<img width="600" alt="image" src="https://github.com/user-attachments/assets/45d9536f-cf60-472e-993f-5c6a6bd438db" />
